### PR TITLE
Bugfix: Fastfail documentStore.addDocument() if userId is null

### DIFF
--- a/desktop/src/stores/documentStore.tsx
+++ b/desktop/src/stores/documentStore.tsx
@@ -51,6 +51,8 @@ export const useDocumentStore = create<DocumentListState>((set) => ({
             const userId = await getUserId() ?? "null";
             if (userId == "null") {
                 console.error("Failed to add documetn because userId cannot be found");
+                toast("Failed to add document")
+                return
             }
             const documentsDir = await join(userId, DOCUMENTS_DIRNAME)
             await mkdir(documentsDir, { baseDir: BaseDirectory.AppData, recursive: true })


### PR DESCRIPTION
Fix for @rickisXD comments on #42 